### PR TITLE
fix: deterministic test embeddings (flaky CI)

### DIFF
--- a/tests/memory/test_dedup.py
+++ b/tests/memory/test_dedup.py
@@ -1,5 +1,6 @@
 """Tests for NANO-102: Memory deduplication — content-hash, similarity gate, session guard."""
 
+import hashlib
 import os
 import shutil
 import tempfile
@@ -23,9 +24,14 @@ from spindl.memory.memory_store import (
 
 
 def _make_embedding(text: str, dim: int = 64) -> list[float]:
-    """Deterministic fake embedding from hash. Same text = same vector."""
-    h = hash(text) % 10000
-    return [(h + i) / 10000.0 for i in range(dim)]
+    """Deterministic fake embedding from hash. Same text = same vector.
+
+    Uses SHA-256 digest bytes to fill each dimension independently,
+    producing vectors that are far apart for different inputs.
+    """
+    digest = hashlib.sha256(text.encode()).digest()
+    # Cycle through digest bytes to fill dim dimensions
+    return [digest[i % len(digest)] / 255.0 for i in range(dim)]
 
 
 def _make_similar_embedding(text: str, offset: float = 0.001, dim: int = 64) -> list[float]:

--- a/tests/memory/test_global_memory.py
+++ b/tests/memory/test_global_memory.py
@@ -1,5 +1,6 @@
 """Tests for global memory tier — NANO-105."""
 
+import hashlib
 import shutil
 import tempfile
 from unittest.mock import MagicMock
@@ -16,8 +17,8 @@ def mock_embedding_client() -> MagicMock:
     client = MagicMock(spec=EmbeddingClient)
 
     def fake_embed(text: str) -> list[float]:
-        h = hash(text) % 10000
-        return [(h + i) / 10000.0 for i in range(64)]
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[i % len(digest)] / 255.0 for i in range(64)]
 
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         return [fake_embed(t) for t in texts]

--- a/tests/memory/test_memory_store.py
+++ b/tests/memory/test_memory_store.py
@@ -1,5 +1,6 @@
 """Tests for MemoryStore — ChromaDB wrapper with per-character collections."""
 
+import hashlib
 import os
 import shutil
 import tempfile
@@ -22,10 +23,9 @@ def mock_embedding_client() -> MagicMock:
     client = MagicMock(spec=EmbeddingClient)
 
     def fake_embed(text: str) -> list[float]:
-        h = hash(text) % 10000
-        # 64-dim fake vector — enough for ChromaDB to work with
-        base = [(h + i) / 10000.0 for i in range(64)]
-        return base
+        # 64-dim fake vector — each dimension from SHA-256 digest bytes
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[i % len(digest)] / 255.0 for i in range(64)]
 
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         return [fake_embed(t) for t in texts]

--- a/tests/memory/test_memory_store_switch.py
+++ b/tests/memory/test_memory_store_switch.py
@@ -7,6 +7,7 @@ Tests cover:
 - Data added after switch is in the new character's collections
 """
 
+import hashlib
 import os
 import shutil
 import tempfile
@@ -26,8 +27,8 @@ def mock_embedding_client() -> MagicMock:
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         results = []
         for text in texts:
-            h = hash(text) % 10000
-            results.append([(h + i) / 10000.0 for i in range(64)])
+            digest = hashlib.sha256(text.encode()).digest()
+            results.append([digest[i % len(digest)] / 255.0 for i in range(64)])
         return results
 
     client.embed_batch.side_effect = fake_embed_batch

--- a/tests/memory/test_rag_injector.py
+++ b/tests/memory/test_rag_injector.py
@@ -3,6 +3,7 @@
 NANO-043 Phase 2.
 """
 
+import hashlib
 import shutil
 import tempfile
 from unittest.mock import MagicMock, patch
@@ -25,8 +26,8 @@ def mock_embedding_client() -> MagicMock:
     client = MagicMock(spec=EmbeddingClient)
 
     def fake_embed(text: str) -> list[float]:
-        h = hash(text) % 10000
-        return [(h + i) / 10000.0 for i in range(64)]
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[i % len(digest)] / 255.0 for i in range(64)]
 
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         return [fake_embed(t) for t in texts]

--- a/tests/memory/test_reflection.py
+++ b/tests/memory/test_reflection.py
@@ -3,6 +3,7 @@
 NANO-043 Phase 3. NANO-104 editable prompt + format-agnostic parser.
 """
 
+import hashlib
 import os
 import shutil
 import tempfile
@@ -41,8 +42,8 @@ def mock_embedding_client() -> MagicMock:
     client = MagicMock(spec=EmbeddingClient)
 
     def fake_embed(text: str) -> list[float]:
-        h = hash(text) % 10000
-        return [(h + i) / 10000.0 for i in range(64)]
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[i % len(digest)] / 255.0 for i in range(64)]
 
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         return [fake_embed(t) for t in texts]

--- a/tests/memory/test_session_summary.py
+++ b/tests/memory/test_session_summary.py
@@ -3,6 +3,7 @@
 NANO-043 Phase 4.
 """
 
+import hashlib
 import os
 import shutil
 import tempfile
@@ -30,8 +31,8 @@ def mock_embedding_client() -> MagicMock:
     client = MagicMock(spec=EmbeddingClient)
 
     def fake_embed(text: str) -> list[float]:
-        h = hash(text) % 10000
-        return [(h + i) / 10000.0 for i in range(64)]
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[i % len(digest)] / 255.0 for i in range(64)]
 
     def fake_embed_batch(texts: list[str]) -> list[list[float]]:
         return [fake_embed(t) for t in texts]


### PR DESCRIPTION
## Summary
- Replace `hash(text) % 10000` with SHA-256 digest bytes in 6 memory test files
- Python's `hash()` is randomized per-process — produced near-identical vectors for short strings on some seeds, causing `test_different_content_different_ids` to flake on CI
- New approach uses each byte of SHA-256 digest as a vector dimension, producing maximally different vectors for different inputs

## Test plan
- [x] Backend: 1,888 passed, 0 failed (was 2 flaky before fix)
- [x] The previously flaky test now passes deterministically
- [ ] CI: awaiting green check

🤖 Generated with [Claude Code](https://claude.com/claude-code)